### PR TITLE
Add marker management with category filtering and editing

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -29,6 +29,9 @@
         <activity
             android:name=".TestActivity"
             android:exported="true"/>
+        <activity
+            android:name=".AddSpotActivity"
+            android:exported="false"/>
 
         <meta-data
             android:name="com.google.android.geo.API_KEY"

--- a/app/src/main/java/jp/ac/jec/cm0128/recommap/AddSpotActivity.java
+++ b/app/src/main/java/jp/ac/jec/cm0128/recommap/AddSpotActivity.java
@@ -2,6 +2,7 @@ package jp.ac.jec.cm0128.recommap;
 
 import android.os.Bundle;
 import android.text.TextUtils;
+import android.view.View;
 import android.widget.ArrayAdapter;
 import android.widget.Button;
 import android.widget.EditText;
@@ -33,7 +34,7 @@ public class AddSpotActivity extends AppCompatActivity implements OnMapReadyCall
     private EditText edtName, edtComment;
     private RatingBar ratingBar;
     private Spinner spCategory;
-    private Button btnAdd;
+    private Button btnAdd, btnUpdate, btnDelete;
 
     private GoogleMap googleMap;
     private Marker marker;
@@ -41,6 +42,7 @@ public class AddSpotActivity extends AppCompatActivity implements OnMapReadyCall
     @NonNull
     private LatLng currentLatLng = TestData.JEC_LATLNG;
     private final ExecutorService executor = Executors.newSingleThreadExecutor();
+    private int editingItemId = -1;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -53,6 +55,8 @@ public class AddSpotActivity extends AppCompatActivity implements OnMapReadyCall
         ratingBar = findViewById(R.id.rating_bar);
         spCategory = findViewById(R.id.sp_category);
         btnAdd = findViewById(R.id.btn_add);
+        btnUpdate = findViewById(R.id.btn_update);
+        btnDelete = findViewById(R.id.btn_delete);
 
         List<String> categoryList = Arrays.stream(ItemCategory.values())
                 .map(ItemCategory::getDisplayName)
@@ -62,6 +66,34 @@ public class AddSpotActivity extends AppCompatActivity implements OnMapReadyCall
         SupportMapFragment mapFragment = (SupportMapFragment) getSupportFragmentManager()
                 .findFragmentById(R.id.map);
         if (mapFragment != null) mapFragment.getMapAsync(this);
+
+        editingItemId = getIntent().getIntExtra("item_id", -1);
+        if (editingItemId != -1) {
+            btnAdd.setVisibility(View.GONE);
+            btnUpdate.setVisibility(View.VISIBLE);
+            btnDelete.setVisibility(View.VISIBLE);
+
+            executor.execute(() -> {
+                Item item = AppDatabase.getInstance(getApplicationContext()).itemDao().findById(editingItemId);
+                if (item != null) {
+                    currentLatLng = new LatLng(item.latitude, item.longitude);
+                    runOnUiThread(() -> {
+                        edtName.setText(item.name);
+                        edtComment.setText(item.comment);
+                        ratingBar.setRating(item.rating);
+                        spCategory.setSelection(ItemCategory.valueOf(item.category).ordinal());
+                        if (googleMap != null && marker != null) {
+                            googleMap.moveCamera(CameraUpdateFactory.newCameraPosition(
+                                    new CameraPosition.Builder().target(currentLatLng).zoom(16f).build()));
+                            marker.setPosition(currentLatLng);
+                        }
+                    });
+                }
+            });
+        } else {
+            btnUpdate.setVisibility(View.GONE);
+            btnDelete.setVisibility(View.GONE);
+        }
 
         btnAdd.setOnClickListener(v -> {
             String name = edtName.getText().toString().trim();
@@ -78,13 +110,44 @@ public class AddSpotActivity extends AppCompatActivity implements OnMapReadyCall
             Item item = new Item(name, comment, rating, currentLatLng.latitude, currentLatLng.longitude, categoryStr);
 
             executor.execute(() -> {
-                AppDatabase.getInstance(this).itemDao().upsert(item);
+                AppDatabase.getInstance(getApplicationContext()).itemDao().upsert(item);
                 runOnUiThread(() -> {
                     Toast.makeText(this, "登録しました", Toast.LENGTH_SHORT).show();
                     finish();
                 });
             });
         });
+
+        btnUpdate.setOnClickListener(v -> {
+            String name = edtName.getText().toString().trim();
+            String comment = edtComment.getText().toString().trim();
+            float rating = ratingBar.getRating();
+            ItemCategory category = ItemCategory.values()[spCategory.getSelectedItemPosition()];
+
+            if (TextUtils.isEmpty(name) || TextUtils.isEmpty(comment)) {
+                Snackbar.make(edtName, "入力が不足しています", Snackbar.LENGTH_SHORT).show();
+                return;
+            }
+
+            Item item = new Item(name, comment, rating, currentLatLng.latitude, currentLatLng.longitude, category.name());
+            item.id = editingItemId;
+
+            executor.execute(() -> {
+                AppDatabase.getInstance(getApplicationContext()).itemDao().upsert(item);
+                runOnUiThread(() -> {
+                    Toast.makeText(this, "更新しました", Toast.LENGTH_SHORT).show();
+                    finish();
+                });
+            });
+        });
+
+        btnDelete.setOnClickListener(v -> executor.execute(() -> {
+            AppDatabase.getInstance(getApplicationContext()).itemDao().deleteById(editingItemId);
+            runOnUiThread(() -> {
+                Toast.makeText(this, "削除しました", Toast.LENGTH_SHORT).show();
+                finish();
+            });
+        }));
     }
 
     @Override

--- a/app/src/main/java/jp/ac/jec/cm0128/recommap/ItemDao.java
+++ b/app/src/main/java/jp/ac/jec/cm0128/recommap/ItemDao.java
@@ -15,6 +15,12 @@ public interface ItemDao {
     @Query("SELECT * FROM items")
     List<Item> getAll();
 
+    @Query("SELECT * FROM items WHERE id = :id LIMIT 1")
+    Item findById(int id);
+
     @Query("DELETE FROM items")
     void deleteAll();
+
+    @Query("DELETE FROM items WHERE id = :id")
+    void deleteById(int id);
 }

--- a/app/src/main/java/jp/ac/jec/cm0128/recommap/TestActivity.java
+++ b/app/src/main/java/jp/ac/jec/cm0128/recommap/TestActivity.java
@@ -2,13 +2,9 @@ package jp.ac.jec.cm0128.recommap;
 
 import android.content.Intent;
 import android.os.Bundle;
-import android.widget.ArrayAdapter;
-import android.widget.EditText;
-import android.widget.RatingBar;
-import android.widget.Spinner;
-import android.widget.TextView;
+import android.widget.Toast;
 
-import androidx.annotation.Nullable;
+import androidx.annotation.NonNull;
 import androidx.appcompat.app.AppCompatActivity;
 
 import com.google.android.gms.maps.CameraUpdateFactory;
@@ -19,112 +15,110 @@ import com.google.android.gms.maps.model.BitmapDescriptorFactory;
 import com.google.android.gms.maps.model.LatLng;
 import com.google.android.gms.maps.model.Marker;
 import com.google.android.gms.maps.model.MarkerOptions;
+import com.google.android.material.chip.ChipGroup;
 
 import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
+/**
+ * 地図上に保存済みのスポットを表示するアクティビティ。
+ * 追加・更新・削除は {@link AddSpotActivity} を利用する。
+ */
 public class TestActivity extends AppCompatActivity implements OnMapReadyCallback {
 
     private GoogleMap googleMap;
-    private EditText edtName, edtComment;
-    private RatingBar ratingBar;
-    private Spinner spCategory;
-    private TextView txtId;
-    private Marker selectedMarker;
-    private final HashMap<Marker, Item> markerMap = new HashMap<>();
+    private ChipGroup chipGroup;
+    private final Map<Marker, Item> markerMap = new HashMap<>();
 
     @Override
-    protected void onCreate(@Nullable Bundle savedInstanceState) {
+    protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        setContentView(R.layout.activity_test); // ← 正しいレイアウト名
+        setContentView(R.layout.activity_test);
 
-        findViewById(R.id.btn_add).setOnClickListener(v -> {
-            Intent intent = new Intent(TestActivity.this, AddSpotActivity.class);
-            startActivity(intent);
+        findViewById(R.id.btn_add).setOnClickListener(v ->
+                startActivity(new Intent(this, AddSpotActivity.class)));
+
+        findViewById(R.id.btn_delete_all).setOnClickListener(v -> {
+            AppDatabase.getInstance(this).itemDao().deleteAll();
+            loadMarkers();
+            Toast.makeText(this, "全件削除しました", Toast.LENGTH_SHORT).show();
         });
 
-        edtName = findViewById(R.id.edt_name);
-        edtComment = findViewById(R.id.edt_comment);
-        ratingBar = findViewById(R.id.rating_bar);
-        spCategory = findViewById(R.id.sp_category);
-        txtId = findViewById(R.id.txt_id);
+        chipGroup = findViewById(R.id.category_chip_group);
+        chipGroup.setOnCheckedStateChangeListener((group, checkedIds) -> filterMarkers());
 
-        ArrayAdapter<String> adapter = new ArrayAdapter<>(
-                this,
-                android.R.layout.simple_spinner_dropdown_item,
-                new String[]{"ラーメン", "コンビニ", "学校", "その他"});
-        spCategory.setAdapter(adapter);
+        SupportMapFragment mapFragment = (SupportMapFragment) getSupportFragmentManager()
+                .findFragmentById(R.id.map);
+        if (mapFragment != null) mapFragment.getMapAsync(this);
+    }
 
-        SupportMapFragment mapFragment = (SupportMapFragment)
-                getSupportFragmentManager().findFragmentById(R.id.map);
-        if (mapFragment != null) {
-            mapFragment.getMapAsync(this);
+    @Override
+    protected void onResume() {
+        super.onResume();
+        if (googleMap != null) {
+            loadMarkers();
         }
     }
 
     @Override
-    public void onMapReady(GoogleMap map) {
-        this.googleMap = map;
-        LatLng start = TestData.JEC_LATLNG;
-        googleMap.moveCamera(CameraUpdateFactory.newLatLngZoom(start, 16f));
+    public void onMapReady(@NonNull GoogleMap map) {
+        googleMap = map;
+        googleMap.moveCamera(CameraUpdateFactory.newLatLngZoom(TestData.JEC_LATLNG, 16f));
 
-        // DBからマーカー読み込みして地図に表示
-        List<Item> savedItems = AppDatabase.getInstance(this).itemDao().getAll();
-        for (Item item : savedItems) {
-            LatLng pos = new LatLng(item.latitude, item.longitude);
+        googleMap.setOnMarkerClickListener(marker -> {
+            marker.showInfoWindow();
+            return true;
+        });
+
+        googleMap.setOnInfoWindowClickListener(marker -> {
+            Item item = markerMap.get(marker);
+            if (item != null) {
+                Intent intent = new Intent(this, AddSpotActivity.class);
+                intent.putExtra("item_id", item.id);
+                startActivity(intent);
+            }
+        });
+
+        loadMarkers();
+    }
+
+    private void loadMarkers() {
+        if (googleMap == null) return;
+
+        googleMap.clear();
+        markerMap.clear();
+
+        List<Item> items = AppDatabase.getInstance(this).itemDao().getAll();
+        for (Item item : items) {
             Marker marker = googleMap.addMarker(new MarkerOptions()
-                    .position(pos)
+                    .position(new LatLng(item.latitude, item.longitude))
                     .title(item.name)
                     .snippet(item.comment + " 評価: " + item.rating)
                     .icon(BitmapDescriptorFactory.defaultMarker(BitmapDescriptorFactory.HUE_ORANGE)));
             markerMap.put(marker, item);
         }
 
-        // マーカー追加（ロングタップ）
-        googleMap.setOnMapLongClickListener(latLng -> {
-            String name = edtName.getText().toString().trim();
-            String comment = edtComment.getText().toString().trim();
-            float rating = ratingBar.getRating();
-            String category = spCategory.getSelectedItem().toString();
-
-            if (name.isEmpty()) {
-                edtName.setError("場所名が必要です");
-                return;
-            }
-
-            String snippet = comment + " 評価: " + rating;
-            Marker marker = googleMap.addMarker(new MarkerOptions()
-                    .position(latLng)
-                    .title(name)
-                    .snippet(snippet)
-                    .icon(BitmapDescriptorFactory.defaultMarker(BitmapDescriptorFactory.HUE_BLUE)));
-
-            Item item = new Item(name, comment, rating, latLng.latitude, latLng.longitude, category);
-            markerMap.put(marker, item);
-            txtId.setText("ID: " + marker.hashCode());
-        });
-
-        // マーカークリック時：情報を入力欄に表示
-        googleMap.setOnMarkerClickListener(marker -> {
-            selectedMarker = marker;
-            Item item = markerMap.get(marker);
-            if (item != null) {
-                edtName.setText(item.name);
-                edtComment.setText(item.comment);
-                ratingBar.setRating(item.rating);
-                spCategory.setSelection(getSpinnerIndex(spCategory, item.category));
-                txtId.setText("ID: " + marker.hashCode());
-            }
-            return false;
-        });
+        filterMarkers();
     }
 
-    private int getSpinnerIndex(Spinner spinner, String value) {
-        for (int i = 0; i < spinner.getCount(); i++) {
-            if (spinner.getItemAtPosition(i).toString().equalsIgnoreCase(value)) {
-                return i;
-            }
+    private void filterMarkers() {
+        if (chipGroup == null) return;
+
+        int checkedId = chipGroup.getCheckedChipId();
+        String category = null;
+        if (checkedId == R.id.chip_ramen) {
+            category = ItemCategory.RAMEN.name();
+        } else if (checkedId == R.id.chip_conveni) {
+            category = ItemCategory.CONVENI.name();
+        } else if (checkedId == R.id.chip_jec) {
+            category = ItemCategory.JEC.name();
         }
-        return 0;
+
+        for (Map.Entry<Marker, Item> entry : markerMap.entrySet()) {
+            boolean visible = category == null || category.equals(entry.getValue().category);
+            entry.getKey().setVisible(visible);
+        }
     }
 }
+


### PR DESCRIPTION
## Summary
- display saved spots on map and edit them
- enable adding, updating, and deleting spot data with marker repositioning
- filter map markers by category and bulk delete from map screen

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68900d64b1988330a4643fed2c83f7ef