### PR TITLE
Move Room queries off UI thread

### DIFF
--- a/app/src/main/java/jp/ac/jec/cm0128/recommap/AppDatabase.java
+++ b/app/src/main/java/jp/ac/jec/cm0128/recommap/AppDatabase.java
@@ -22,7 +22,7 @@ public abstract class AppDatabase extends RoomDatabase {
                                     context.getApplicationContext(),
                                     AppDatabase.class,
                                     "recommap_db"
-                            ).allowMainThreadQueries() // for test only
+                            )
                             .build();
                 }
             }


### PR DESCRIPTION
## Summary
- remove allowMainThreadQueries from AppDatabase
- run database access in TestActivity on background executor and update UI on main thread

## Testing
- `./gradlew test` *(fails: The file '/workspace/RecomMap/local.properties' could not be found)*

------
https://chatgpt.com/codex/tasks/task_e_6890169d1abc8330a70b1a96c48c299f